### PR TITLE
Better error handling for email confirmations

### DIFF
--- a/app/routes/index.js
+++ b/app/routes/index.js
@@ -80,8 +80,14 @@ router.get("/confirm/:token", function(req, res){
 	var m = mongo.getModel("User");
 
 	m.findOne({email_token: req.params.token}, function(err, doc){
-		if (err)
-			return res.render("pages/index", {error: err});
+		if (err){
+			req.session.error = err;
+			return res.redirect("/");
+		}
+		if (!doc){
+			req.session.error = "Sorry, that token doesn't exist";
+			return res.redirect("/");
+		}
 
 		if (doc.email_expires < Date.now())
 			return res.render("pages/index", {error: "Confirmation expired.. Please sign up again."});

--- a/app/views/pages/index.ejs
+++ b/app/views/pages/index.ejs
@@ -3,7 +3,7 @@
     <head>
         <% title="Home" %>
         <% include ../partials/head %>
-        <link href="./css/main.css" rel="stylesheet" />
+        <link href="/css/main.css" rel="stylesheet" />
     </head>
 
     <body>
@@ -59,7 +59,7 @@
         <!-- /.container -->
         <% include ../partials/footer %>
         <!-- /.container -->
-        <script src="./js/holder.js"></script>
+        <script src="/js/holder.js"></script>
 
         <script>
             $(".carousel").carousel({


### PR DESCRIPTION
The `/confirm` route now has better error hanling... If the token provided doesn't match any of our records, send an error message.